### PR TITLE
BREAKING CHANGE: 适配 nonebot2 2.0.0-rc.1

### DIFF
--- a/nonebot_plugin_strman/__init__.py
+++ b/nonebot_plugin_strman/__init__.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
 
 from nonebot.config import Config as NBConfig
 from nonebot.log import logger
-from nonebot.plugin.export import export
 
 from .parser import Parser
 
@@ -15,7 +14,6 @@ __version__ = version("nonebot_plugin_strman")
 logger.success(f"Plugin loaded: <b>NoneBot String Manager v{__version__}</b>")
 
 
-@export()
 def init(
     impl: Optional[Type["Message"]] = None,
     **config: Union[NBConfig, Dict[str, Any], str],

--- a/nonebot_plugin_strman/parser.py
+++ b/nonebot_plugin_strman/parser.py
@@ -1,7 +1,6 @@
 """字符串管理解析器"""
 import json
 import random
-import warnings
 from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Type, Union
@@ -77,43 +76,6 @@ class Parser(object):
             )
             return raw.format(*args, **kwargs)
         return self.impl.template(raw).format(*args, **kwargs)
-
-    def parse(
-        self,
-        tag: str,
-        /,
-        *args: Any,
-        profile_ol: Optional[str] = None,
-        **kwargs: Any,
-    ) -> Union["Message", str]:
-        """
-        解析字符串标签获取内容。
-
-        此方法将在 v1.2 后弃用，请直接调用实例对象：
-
-        ```python
-        >>> parser = Parser(...)
-        >>> parser(tag, *args, **kwargs)
-        ```
-        ---
-        参数：
-        - `tag: str`：字符串标签；
-        - `profile_ol: Optional[str]`：重载字符串预设名称，默认遵循
-          `STRMAN_PROFILE` 所指定的默认预设配置；
-        - `*args, **kwargs: Any`：替换内容。
-
-        返回：
-        - `Union[Message, str]`：字符串标签解析内容。指定消息实现时则包装为指定
-          的 `Message` 对象，否则返回字符串。
-        """
-        warnings.warn(
-            (
-                "This method is about to be deprecated in v1.2. You should now call "
-                "the instance object directly."
-            ),
-            category=DeprecationWarning,
-        )
-        return self.__call__(tag, *args, profile_ol=profile_ol, **kwargs)
 
     @staticmethod
     def _tag_parse(tag: str, contents: Dict[str, Any]) -> str:

--- a/poetry.lock
+++ b/poetry.lock
@@ -17,7 +17,7 @@ trio = ["trio (>=0.16)"]
 
 [[package]]
 name = "astroid"
-version = "2.12.10"
+version = "2.12.11"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
@@ -213,11 +213,11 @@ python-versions = "*"
 
 [[package]]
 name = "nonebot2"
-version = "2.0.0b5"
+version = "2.0.0rc1"
 description = "An asynchronous python bot framework."
 category = "main"
 optional = false
-python-versions = ">=3.7.3,<4.0.0"
+python-versions = ">=3.8,<4.0"
 
 [package.dependencies]
 fastapi = ">=0.79.0,<0.80.0"
@@ -313,14 +313,14 @@ python-versions = "*"
 
 [[package]]
 name = "pylint"
-version = "2.15.3"
+version = "2.15.4"
 description = "python code static checker"
 category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 
 [package.dependencies]
-astroid = ">=2.12.10,<=2.14.0-dev0"
+astroid = ">=2.12.11,<=2.14.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 dill = ">=0.2"
 isort = ">=4.2.5,<6"
@@ -519,7 +519,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7c6f6d4dd7530c1961283d849c3fe785f947a87b0d80a4f1b1d9999101e18eec"
+content-hash = "a0bc3e340d8273abb8ecf498450a28392467a53741551c1ff47f450fb1a76dd6"
 
 [metadata.files]
 anyio = [
@@ -527,8 +527,8 @@ anyio = [
     {file = "anyio-3.6.1.tar.gz", hash = "sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b"},
 ]
 astroid = [
-    {file = "astroid-2.12.10-py3-none-any.whl", hash = "sha256:997e0c735df60d4a4caff27080a3afc51f9bdd693d3572a4a0b7090b645c36c5"},
-    {file = "astroid-2.12.10.tar.gz", hash = "sha256:81f870105d892e73bf535da77a8261aa5bde838fa4ed12bb2f435291a098c581"},
+    {file = "astroid-2.12.11-py3-none-any.whl", hash = "sha256:867a756bbf35b7bc07b35bfa6522acd01f91ad9919df675e8428072869792dce"},
+    {file = "astroid-2.12.11.tar.gz", hash = "sha256:2df4f9980c4511474687895cbfdb8558293c1a826d9118bb09233d7c2bff1c83"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
@@ -745,8 +745,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nonebot2 = [
-    {file = "nonebot2-2.0.0b5-py3-none-any.whl", hash = "sha256:5cfbfcd62ffcf55f884f9fb750a71cd92c97e347c99e891ef617da4d445a1f22"},
-    {file = "nonebot2-2.0.0b5.tar.gz", hash = "sha256:fccb5af749cceb289d756901b7abc7a679e5952dbe88c8b6ad8b2d906715c3ee"},
+    {file = "nonebot2-2.0.0rc1-py3-none-any.whl", hash = "sha256:99c70300b9d0755bba6ed50b7399f44f6213e119157bc026b960b3e157a38416"},
+    {file = "nonebot2-2.0.0rc1.tar.gz", hash = "sha256:6e5a0abf24086d05d5c2a56c971a551ece2a343ff29f83b76b398bf717b92e16"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -810,8 +810,8 @@ pygtrie = [
     {file = "pygtrie-2.5.0.tar.gz", hash = "sha256:203514ad826eb403dab1d2e2ddd034e0d1534bbe4dbe0213bb0593f66beba4e2"},
 ]
 pylint = [
-    {file = "pylint-2.15.3-py3-none-any.whl", hash = "sha256:7f6aad1d8d50807f7bc64f89ac75256a9baf8e6ed491cc9bc65592bc3f462cf1"},
-    {file = "pylint-2.15.3.tar.gz", hash = "sha256:5fdfd44af182866999e6123139d265334267339f29961f00c89783155eacc60b"},
+    {file = "pylint-2.15.4-py3-none-any.whl", hash = "sha256:629cf1dbdfb6609d7e7a45815a8bb59300e34aa35783b5ac563acaca2c4022e9"},
+    {file = "pylint-2.15.4.tar.gz", hash = "sha256:5441e9294335d354b7bad57c1044e5bd7cce25c433475d76b440e53452fa5cb8"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "nonebot-plugin-strman"
-version = "1.1.1"
+version = "1.2.0"
 description = "A string management tool for NoneBot 2"
 authors = ["Satoshi Jek <jks15satoshi@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-nonebot2 = "2.0.0-beta.5"
+nonebot2 = "^2.0.0-rc.1"
 
 [tool.poetry.dev-dependencies]
 black = "^22.8.0"

--- a/tests/test_parse_tag.py
+++ b/tests/test_parse_tag.py
@@ -99,8 +99,3 @@ def test_parse_tag_with_format(
         parse(tag, *args, **kwargs).extract_plain_text()
         == Message(expected).extract_plain_text()
     )
-
-
-def test_parse_tag_with_deprecated_method(parse) -> None:
-    with pytest.deprecated_call():
-        assert parse.parse("tag_value").extract_plain_text() == "Layer 1"


### PR DESCRIPTION
- 移除 `nonebot.export` 调用；
- 移除 `Parser.parse` 方法。